### PR TITLE
Avoid shadowing offset variable

### DIFF
--- a/lib/src/parsers/blockquote_list.dart
+++ b/lib/src/parsers/blockquote_list.dart
@@ -435,7 +435,8 @@ class _InnerBlocksParser extends AbstractParser<Iterable<BlockNodeImpl>> {
 
   @override
   ParseResult<Iterable<BlockNodeImpl>> parse(String text, int offset) {
-    int offset = 0;
+    // ignore: parameter_assignments
+    offset = 0; // Force 0
     final List<BlockNodeImpl> blocks = <BlockNodeImpl>[];
 
     final int length = text.length;

--- a/lib/src/parsers/document.dart
+++ b/lib/src/parsers/document.dart
@@ -201,7 +201,8 @@ class DocumentParser extends AbstractParser<Document> {
 
   @override
   ParseResult<Document> parse(String text, int offset) {
-    int offset = 0;
+    // ignore: parameter_assignments
+    offset = 0; // Force 0
     final List<BlockNodeImpl> blocks = <BlockNodeImpl>[];
 
     final int length = text.length;


### PR DESCRIPTION
With the DDC, shadowing variables doesn't work. This removes the occurrences in this library.